### PR TITLE
Oracle Linux 6 and Puppet 0.25.4 / Facter 1.5.6 support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,7 +14,7 @@ class ntp::params {
       $defaults_file_tpl = 'ntp.defaults.debian.erb'
       $ntpd_start_options = '-g'
     }
-    'centos', 'redhat', 'fedora', 'scientific', 'oel': {
+    'centos', 'redhat', 'fedora', 'scientific', 'oel', 'oraclelinux': {
       $service_name = 'ntpd'
       $driftfile = '/var/lib/ntp/drift'
       $config_file_owner = 'root'


### PR DESCRIPTION
- uses $::operatingsystem instead of $::osfamily to support older Facter/Puppet versions
- testet with CentOS 5.8, CentOS 6.0 - 6.3, Oracle Linux 6.1,  Oracle Linux 6.3, Ubuntu 10.04 LTS, Ubuntu 12.04 LTS
