### PR TITLE
make statsdir an empty variable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -120,7 +120,7 @@ class ntp(
   $interface_ignore = [],
   $interface_listen = [],
   $enable_statistics = false,
-  $statsdir = undef,
+  $statsdir = '',
   $ensure = 'present',
   $autoupgrade = false,
   $package = $ntp::params::package,


### PR DESCRIPTION
This allows the module to work in foreman 1.1 with puppet puppet-3.0.2, otherwise the puppet run would fail with: 

Error 400 on SERVER: Received incomplete information - no value provided for parameter statsdir on node $nodename
