### PR TITLE
Addressed template variable warnings after upgrading to Puppet 3.2

### DIFF
--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -1,19 +1,19 @@
 # file is managed by puppet
 
-driftfile <%= driftfile %>
+driftfile <%= @driftfile %>
 
-<% if interface_ignore.empty? == false then -%>
+<% if @interface_ignore.empty? == false then -%>
 <% interface_ignore.each do |int_ignore| -%>
 interface ignore <%= int_ignore %>
 <% end -%>
 <% end -%>
-<% if interface_listen.empty? == false then -%>
+<% if @interface_listen.empty? == false then -%>
 <% interface_listen.each do |int_listen| -%>
 interface listen <%= int_listen %>
 <% end -%>
 <% end -%>
 
-<% if enable_statistics == true -%>
+<% if @enable_statistics == true -%>
 # Enable this if you want statistics to be logged.                             
 statsdir <%= statsdir %>
 statistics loopstats peerstats clockstats
@@ -22,11 +22,11 @@ filegen peerstats file peerstats type day enable
 filegen clockstats file clockstats type day enable
 <% end -%>
 
-<% server_list.each do |server| -%>
+<% @server_list.each do |server| -%>
 server <%= server %>
 <% end -%>
 
-<% if server_enabled == true -%>
+<% if @server_enabled == true -%>
 # By default, exchange time with everybody, but don't allow configuration.
 restrict -4 default kod notrap nomodify nopeer noquery
 restrict -6 default kod notrap nomodify nopeer noquery
@@ -36,7 +36,7 @@ restrict -6 default kod notrap nomodify nopeer noquery
 restrict 127.0.0.1
 restrict ::1
 
-<% if server_enabled == true -%>
+<% if @server_enabled == true -%>
 <% if query_networks.empty? == false -%>
 # Clients from this subnet have unlimited access, but only if
 # cryptographically authenticated.

--- a/templates/ntp.defaults.debian.erb
+++ b/templates/ntp.defaults.debian.erb
@@ -1,3 +1,3 @@
 # file is managed by puppet
 
-NTPD_OPTS="<%= ntpd_start_options %>"
+NTPD_OPTS="<%= @ntpd_start_options %>"

--- a/templates/ntp.defaults.redhat.erb
+++ b/templates/ntp.defaults.redhat.erb
@@ -1,4 +1,4 @@
 # file is managed by puppet
 
 # Drop root to id 'ntp:ntp' by default.
-OPTIONS="<%= ntpd_start_options %>"
+OPTIONS="<%= @ntpd_start_options %>"


### PR DESCRIPTION
Using this module with Puppet 3.2.1 resulted in a lot of warnings such as the following:

`Warning: Variable access via 'driftfile' is deprecated. Use '@driftfile' instead.`

The warnings no longer appear if these modified templates are used.
