### PR TITLE
Use instance variables in template files (Puppet 3.x compatibility)

### DIFF
--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -1,32 +1,32 @@
 # file is managed by puppet
 
-driftfile <%= driftfile %>
+driftfile <%= @driftfile %>
 
-<% if interface_ignore.empty? == false then -%>
-<% interface_ignore.each do |int_ignore| -%>
+<% if @interface_ignore.empty? == false then -%>
+<% @interface_ignore.each do |int_ignore| -%>
 interface ignore <%= int_ignore %>
 <% end -%>
 <% end -%>
-<% if interface_listen.empty? == false then -%>
-<% interface_listen.each do |int_listen| -%>
+<% if @interface_listen.empty? == false then -%>
+<% @interface_listen.each do |int_listen| -%>
 interface listen <%= int_listen %>
 <% end -%>
 <% end -%>
 
-<% if enable_statistics == true -%>
+<% if @enable_statistics == true -%>
 # Enable this if you want statistics to be logged.                             
-statsdir <%= statsdir %>
+statsdir <%= @statsdir %>
 statistics loopstats peerstats clockstats
 filegen loopstats file loopstats type day enable
 filegen peerstats file peerstats type day enable
 filegen clockstats file clockstats type day enable
 <% end -%>
 
-<% server_list.each do |server| -%>
+<% @server_list.each do |server| -%>
 server <%= server %>
 <% end -%>
 
-<% if server_enabled == true -%>
+<% if @server_enabled == true -%>
 # By default, exchange time with everybody, but don't allow configuration.
 restrict -4 default kod notrap nomodify nopeer noquery
 restrict -6 default kod notrap nomodify nopeer noquery
@@ -36,12 +36,12 @@ restrict -6 default kod notrap nomodify nopeer noquery
 restrict 127.0.0.1
 restrict ::1
 
-<% if server_enabled == true -%>
-<% if query_networks.empty? == false -%>
+<% if @server_enabled == true -%>
+<% if @query_networks.empty? == false -%>
 # Clients from this subnet have unlimited access, but only if
 # cryptographically authenticated.
 # Required for some Nagios checks
-<% query_networks.each do |network| -%>
+<% @query_networks.each do |network| -%>
 <% net = network.split('/') -%>
 restrict <%= net[0] %> mask <%= net[1] %>
 <% end -%>

--- a/templates/ntp.defaults.debian.erb
+++ b/templates/ntp.defaults.debian.erb
@@ -1,3 +1,3 @@
 # file is managed by puppet
 
-NTPD_OPTS="<%= ntpd_start_options %>"
+NTPD_OPTS="<%= @ntpd_start_options %>"

--- a/templates/ntp.defaults.redhat.erb
+++ b/templates/ntp.defaults.redhat.erb
@@ -1,4 +1,4 @@
 # file is managed by puppet
 
 # Drop root to id 'ntp:ntp' by default.
-OPTIONS="<%= ntpd_start_options %>"
+OPTIONS="<%= @ntpd_start_options %>"


### PR DESCRIPTION
The variable lookup rules changed for Puppet 3.0. Details about referencing variables within templates can be found at http://docs.puppetlabs.com/guides/templating.html#referencing-variables

This pull request updates the templates of this Puppet module to use instance variables where appropriate to get rid of deprecation warnings in Puppet 3.x.
