### PR TITLE
Support iburst as server config option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ you can set $query_networks in the follwing way:
 * config_file: string, default: OS specific. Set config_file, if platform is not supported. 
 * config_file_replace: true or false, default: true
 * driftfile: string, default: OS specific. Set driftfile, if platform is not supported. 
+* server_iburst: use iburst as server option
 * service_ensure: running or stopped, default: running
 * service_name: string, default: OS specific. Set service_name, if platform is not supported. 
 * service_enable: true or false, default: true

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -116,6 +116,7 @@ class ntp(
     '3.pool.ntp.org',
   ],
   $server_enabled = false,
+  $server_iburst = false,
   $query_networks = [],
   $interface_ignore = [],
   $interface_listen = [],

--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -23,7 +23,10 @@ filegen clockstats file clockstats type day enable
 <% end -%>
 
 <% @server_list.each do |server| -%>
-server <%= server %>
+server <%= server -%>
+	<% if @server_iburst == true -%>
+		<%--%>iburst<%--%>
+	<% end %>
 <% end -%>
 
 <% if @server_enabled == true -%>


### PR DESCRIPTION
Allow adding 'iburst' as server option.

```
iburst
     When the server is unreachable, send a burst of eight packets instead of the usual one. The packet
spacing is normally 2 s; however, the spacing between the first two packets can be changed with the
calldelay command to allow additional time for a modem or ISDN call to complete. This is designed to speed
the initial synchronization acquisition with the server command and s addresses and when ntpd(8) is started
with the -q option.
```
