### PR TITLE
fix service name for opensusse 13.2

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -46,7 +46,11 @@ class ntp::params {
     'Suse': {
       $package = 'ntp'
       $config_file = '/etc/ntp.conf'
-      $service_name = 'ntp'
+      if $::operatingsystemrelease == '13.2' {
+        $service_name = 'ntpd'
+      } else {
+        $service_name = 'ntp'
+      }
       $driftfile = '/var/lib/ntp/drift/ntp.drift'
     }
     'Gentoo': {


### PR DESCRIPTION
opensuse changed the ntp service name from "ntp" to "ntpd"
