### PR TITLE
added whitespace for server_options output in ntp.conf template

### DIFF
--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -23,7 +23,7 @@ filegen clockstats file clockstats type day enable
 <% end -%>
 
 <% @server_list.each do |server| -%>
-server <%= server %><%- if @server_options -%><%= @server_options %><%- end %>
+server <%= server %><%- if @server_options -%> <%= @server_options %><%- end %>
 <% end -%>
 
 <% if @server_enabled == true -%>


### PR DESCRIPTION
Needed to add a space to prevent a bug when setting the server_options parameter.

diff after update:

--- /etc/ntp.conf	2015-12-15 17:29:34.286007043 +1100
+++ /tmp/puppet-file20160126-22854-x05buh	2016-01-26 13:16:30.360062280 +1100
@@ -4,11 +4,11 @@

+server 0.au.pool.ntp.org iburst
+server 1.au.pool.ntp.org iburst
+server 2.au.pool.ntp.org iburst
+server 3.au.pool.ntp.org iburst
+server ntp.ubuntu.com iburst
-server 0.au.pool.ntp.orgiburst
-server 1.au.pool.ntp.orgiburst
-server 2.au.pool.ntp.orgiburst
-server 3.au.pool.ntp.orgiburst
-server ntp.ubuntu.comiburst