### PR TITLE
Fix OS release detection

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,7 @@ class ntp::params {
       case $::operatingsystem {
         'RedHat', 'CentOS', 'Scientific', 'SLC', 'OracleLinux', 'OVS', 'OEL': {
           $majdistrelease = $::lsbmajdistrelease ? {
-            ''      => regsubst($::operatingsystemrelease,'^(\d+)\.(\d+)','\1'),
+            ''      => regsubst($::operatingsystemrelease,'^(\d+)\.[\d.]+','\1'),
             default => $::lsbmajdistrelease,
           }
           $ntpd_start_options = '-u ntp:ntp -p /var/run/ntpd.pid -g'


### PR DESCRIPTION
Support OS release numbers with more than 2 groups of digits.
Fixes #21