### PR TITLE
Evaluation error: comparison of String >=Integer is not possible

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,7 +25,7 @@ class ntp::params {
             default => $::lsbmajdistrelease,
           }
           $ntpd_start_options = '-u ntp:ntp -p /var/run/ntpd.pid -g'
-          if $majdistrelease >= 6 {
+          if $majdistrelease >= '6' {
             $ntpdate_package = 'ntpdate'
             $ntpdate_config_file = '/etc/ntp/step-tickers'
             $ntpdate_defaults_file = '/etc/sysconfig/ntpdate'


### PR DESCRIPTION
If the option parser=future is activated than the comparison $majdistrelease >= 6 will lead to the above mentioned error.
Quoting will fix this.