### PR TITLE
undef not '' matches when facter can't find a fact

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,7 @@ class ntp::params {
       case $::operatingsystem {
         'RedHat', 'CentOS', 'Scientific', 'SLC', 'OracleLinux', 'OVS', 'OEL': {
           $majdistrelease = $::lsbmajdistrelease ? {
-            ''      => regsubst($::operatingsystemrelease,'^(\d+)\.[\d.]+','\1'),
+            undef   => regsubst($::operatingsystemrelease,'^(\d+)\.[\d.]+','\1'),
             default => $::lsbmajdistrelease,
           }
           $ntpd_start_options = '-u ntp:ntp -p /var/run/ntpd.pid -g'


### PR DESCRIPTION
On Centos 6, I was having trouble getting this to work properly. redhat-lsb-core is not installed by default and 'facter lsbmajdistrelease' returns nothing. It would seem that 'undef' is a better way to check for an empty response.