### PR TITLE
Enabled the use of ntp pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Adding options to one specific server
 
 ## Other class parameters
 * server_options: string, default: ''
+* pool_list: string, default: []
+* pool_options: string, default: ''
 * interface_ignore: array, default: []
 * interface_listen: array, default: []
 * enable_statistics: true or false, default: false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,14 @@
 #     Pass options to all servers listed in server_list
 #     Default: ''
 #
+#   [*pool_list*]
+#     List of NTP pools to use.
+#     Default: []
+#
+#   [*pool_options*]
+#     Pass options to all pools listed in pool_list
+#     Default: ''
+#
 #   [*server_enabled*]
 #     Enable ntp server mode.
 #     Default: false
@@ -120,6 +128,8 @@ class ntp(
     '3.pool.ntp.org',
   ],
   $server_options = '',
+  $pool_list = [],
+  $pool_options = '',
   $server_enabled = false,
   $query_networks = [],
   $interface_ignore = [],

--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -25,6 +25,9 @@ filegen clockstats file clockstats type day enable
 <% @server_list.each do |server| -%>
 server <%= server %><%- if @server_options -%> <%= @server_options %><%- end %>
 <% end -%>
+<% @pool_list.each do |pool| -%>
+pool <%= pool %><%- if @pool_options -%> <%= @pool_options %><%- end %>
+<% end -%>
 
 <% if @server_enabled == true -%>
 # By default, exchange time with everybody, but don't allow configuration.


### PR DESCRIPTION
Added support for using ntp pools.
Example:
pool pool.ntp.org

instead of 

server 0.pool.ntp.org
server 1.pool.ntp.org
server 2.pool.ntp.org
server 3.pool.ntp.org