### PR TITLE
Added restrict source line to ntp.conf if ntp pools are used

### DIFF
--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -38,6 +38,10 @@ restrict -6 default kod notrap nomodify nopeer noquery
 restrict -4 default nomodify nopeer noquery notrap
 restrict -6 default nomodify nopeer noquery notrap
 <% end -%>
+<% if @pool_list.length >= 1 -%>
+# When using the pool associations and nopeer a restrict source without nopeer should be added. https://www.eecis.udel.edu/~mills/ntp/html/accopt.html#restrict
+restrict source kod notrap nomodify noquery
+<% end -%>
 
 # Local users may interrogate the ntp server more closely.
 restrict 127.0.0.1


### PR DESCRIPTION
Using NTP pools and nopeer ahve some issues. To solve this a restrict
sourc line without nopeer can be added according to
https://www.eecis.udel.edu/~mills/ntp/html/accopt.html#restrict